### PR TITLE
Amend insert to handle table unique constraint

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1,6 +1,5 @@
 import logger from '../util/logger';
 import { dbConnection } from './dbConnection';
-import { Knex } from 'knex';
 import { VehicleBooking } from '../interfaces/VehicleBooking';
 import { VtBooking } from '../interfaces/VtBooking';
 
@@ -9,7 +8,12 @@ export const insertVtBooking = async function (
 ): Promise<string[]> {
   logger.info('insertVtBooking starting');
 
+  const connection = await dbConnection();
+
   const vehicleBooking = new VehicleBooking();
+  vehicleBooking.FK_BKGHDR_NO = connection.raw(
+    "COALESCE((SELECT MAX(FK_BKGHDR_NO) + 1 from VEHICLE_BOOKING where FK_BKGHDR_USER_NO = 'XR'), 1)",
+  );
   vehicleBooking.SHORT_NAME = booking.name;
   vehicleBooking.VEHICLE_CLASS = 'V';
   vehicleBooking.NO_OF_AXLES = 2;
@@ -20,8 +24,6 @@ export const insertVtBooking = async function (
   vehicleBooking.FK_STATN_ID = booking.pNumber;
   vehicleBooking.FK_VEH_SYST_NO = 1234567;
   vehicleBooking.COUNTED_AXLES = 2;
-
-  const connection: Knex<unknown, unknown[]> = await dbConnection();
 
   const insertResult: string[] = connection
     .insert([vehicleBooking], ['VEHICLE_BOOKING_NO'])

--- a/src/interfaces/VehicleBooking.ts
+++ b/src/interfaces/VehicleBooking.ts
@@ -1,9 +1,11 @@
+import { Knex } from 'knex';
+
 export class VehicleBooking {
   FK_BKGHDR_USER_LOC = 999;
 
   FK_BKGHDR_USER_NO = 'XR';
 
-  FK_BKGHDR_NO = 8001;
+  FK_BKGHDR_NO: Knex.Raw<unknown>;
 
   VEHICLE_BOOKING_NO = 1;
 

--- a/tests/database/database.test.ts
+++ b/tests/database/database.test.ts
@@ -8,12 +8,10 @@ import { VehicleBooking } from '../../src/interfaces/VehicleBooking';
 
 jest.mock('knex');
 const mknex = mocked(knex, true);
-const ent = {
-  VEHICLE_BOOKING_NO: 1,
-};
 const mKnex = {
   insert: jest.fn().mockReturnThis(),
-  into: jest.fn(() => [ent]),
+  into: jest.fn(() => [{ VEHICLE_BOOKING_NO: 1 }]),
+  raw: jest.fn(() => null),
 } as unknown as Knex;
 
 mknex.mockImplementation(
@@ -36,7 +34,7 @@ const vehicleBooking: VehicleBooking = {
   FK_BKGHDR2_NO: null,
   FK_BKGHDR2_USER_LO: null,
   FK_BKGHDR2_USER_NO: null,
-  FK_BKGHDR_NO: 8001,
+  FK_BKGHDR_NO: null,
   FK_BKGHDR_USER_LOC: 999,
   FK_BKGHDR_USER_NO: 'XR',
   FK_LANTBD_DATE: new Date('2022-08-15 10:00:00'),


### PR DESCRIPTION
# Description
Jira ticket [CB2-5428](https://dvsa.atlassian.net/browse/CB2-5428).
There is a unique constraint across the FK_BKGHDR_USER_LOC, FK_BKGHDR_USER_NO, FK_BKGHDR_NO, VEHICLE_BOOKING_NO, and COMBI_NUM columns of the VEHICLE_BOOKING table. The insert statement needs to increment FK_BKGHDR_NO with each insert.
# Evidence of completion
## Constraint added to the table.
![image](https://user-images.githubusercontent.com/13391709/185637714-0226bd49-f30a-4d76-806e-2d37ef7ca7d6.png)
## Tested with an manual insert.
![image](https://user-images.githubusercontent.com/13391709/185637829-39a6c99b-9120-4e02-8309-93797ac140a2.png)
## Code temporarily modified to process the same event 150 times and called once.
![image](https://user-images.githubusercontent.com/13391709/185637881-8ad9d70d-5e32-4efe-8fd3-d5885cc48e92.png)
## Within 720ms all 150 inserts occurred without violating the constraint.
![image](https://user-images.githubusercontent.com/13391709/185637916-044bd920-2e25-4166-bd6c-80b1dc1f6790.png)