### PR TITLE
CB2-5252 Check for existing vehicle booking

### DIFF
--- a/src/database/vehicleBookingDb.ts
+++ b/src/database/vehicleBookingDb.ts
@@ -1,5 +1,6 @@
 import { dbConnection } from './dbConnection';
 import { VehicleBooking } from '../interfaces/VehicleBooking';
+import { VtBooking } from '../interfaces/VtBooking';
 
 export const vehicleBookingDb = {
   async insert(vehicleBooking: VehicleBooking): Promise<void> {
@@ -16,5 +17,18 @@ export const vehicleBookingDb = {
     if (results.length === 0) {
       throw new Error('Insert failed. No data returned.');
     }
+  },
+
+  async get(vtBooking: VtBooking): Promise<VehicleBooking[]> {
+    const connection = await dbConnection();
+
+    const results: VehicleBooking[] = await connection
+      .select()
+      .from<VehicleBooking>('VEHICLE_BOOKING')
+      .where('VRM', vtBooking.vrm)
+      .andWhere('FK_LANTBD_DATE', new Date(vtBooking.testDate))
+      .andWhere('FK_APPTYP_APPL_TYP', vtBooking.testCode);
+
+    return results;
   },
 };

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -26,7 +26,7 @@ export const handler = async (event: SQSEvent): Promise<string> => {
     }
   }
 
-  return Promise.resolve('Event processed.');
+  return Promise.resolve('Events processed.');
 };
 
 function isEventUndefined(event: SQSEvent): boolean {

--- a/src/vehicleBooking/vehicleBooking.ts
+++ b/src/vehicleBooking/vehicleBooking.ts
@@ -8,6 +8,16 @@ export const vehicleBooking = {
   async insert(vtBooking: VtBooking): Promise<void> {
     logger.info('vehicleBooking insert starting');
 
+    const existingBookings = await vehicleBookingDb.get(vtBooking);
+
+    if (existingBookings.length > 0) {
+      logger.info(
+        `Booking for ${vtBooking.testCode} already exists for ${vtBooking.vrm} on ${vtBooking.testDate}.`,
+      );
+
+      return;
+    }
+
     const vehicle = await vehicleDb.get(vtBooking.vrm);
 
     const booking = {

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -29,7 +29,7 @@ describe('handler function', () => {
       '{"name":"Success","bookingDate": "2022-08-10 10:00:00","vrm":"AB12CDE","testCode":"AAV","testDate":"2022-08-15 10:00:00","pNumber":"P12345"}';
     const res: string = await handler(bookingEvent);
 
-    expect(res).toBe('Event processed.');
+    expect(res).toBe('Events processed.');
   });
 
   it('GIVEN an event WHEN an error is thrown THEN the error is returned by the handler.', async () => {

--- a/tests/resources/event.json
+++ b/tests/resources/event.json
@@ -1,7 +1,7 @@
 {
   "Records": [
     {
-      "body": "{\"name\":\"Bob's ATF\",\"bookingDate\": \"2022-08-10 10:00:00\",\"vrm\":\"AB12CDE\",\"testCode\":\"AAV\",\"testDate\":\"2022-08-15 10:00:00\",\"pNumber\":\"P12345\"}",
+      "body": "{\"name\":\"Bob's ATF\",\"bookingDate\": \"2022-08-10 10:00:00\",\"vrm\":\"AB12CDE\",\"testCode\":\"AAV\",\"testDate\":\"2022-08-15 00:00:00\",\"pNumber\":\"P12345\"}",
       "messageId": "string",
       "receiptHandle": "string",
       "attributes": "SQSRecordAttributes",

--- a/tests/vehicleBooking/vehicleBooking.test.ts
+++ b/tests/vehicleBooking/vehicleBooking.test.ts
@@ -1,10 +1,13 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import event from '../resources/event.json';
+import logger from '../../src/util/logger';
 import { vehicleBooking } from '../../src/vehicleBooking/vehicleBooking';
 import { VehicleBooking } from '../../src/interfaces/VehicleBooking';
 import { vehicleBookingDb } from '../../src/database/vehicleBookingDb';
 import { VtBooking } from '../../src/interfaces/VtBooking';
 import { vehicleDb } from '../../src/database/vehicleDb';
+
+jest.mock('../../src/util/logger');
 
 jest.mock('../../src/database/vehicleDb', () => {
   return {
@@ -24,6 +27,10 @@ jest.mock('../../src/database/vehicleBookingDb', () => {
   return {
     vehicleBookingDb: {
       insert: jest.fn(() => {}),
+      get: jest
+        .fn()
+        .mockImplementationOnce(() => [])
+        .mockImplementationOnce(() => [{ vrm: 'AB12CDE' }]),
     },
   };
 });
@@ -43,10 +50,26 @@ booking.FK_VEH_SYST_NO = 123454;
 booking.COUNTED_AXLES = 3;
 
 describe('vehicleBooking functions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('GIVEN everything is okay WHEN the booking is processed THEN the objects are mapped correctly.', async () => {
     await vehicleBooking.insert(vtBooking);
 
+    expect(vehicleBookingDb.get).toBeCalledWith(vtBooking);
     expect(vehicleDb.get).toBeCalledWith('AB12CDE');
     expect(vehicleBookingDb.insert).toBeCalledWith(booking);
+  });
+
+  it('GIVEN a booking already exists WHEN the an attempt to insert the same booking is attempted THEN the insert is skipped.', async () => {
+    await vehicleBooking.insert(vtBooking);
+
+    expect(vehicleBookingDb.get).toBeCalledWith(vtBooking);
+    expect(logger.info).toHaveBeenCalledWith(
+      'Booking for AAV already exists for AB12CDE on 2022-08-15 00:00:00.',
+    );
+    expect(vehicleDb.get).toHaveBeenCalledTimes(0);
+    expect(vehicleBookingDb.insert).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
## Description

Before inserting a vehicle booking, check one doesn't already exist.

Related issue: [CB2-5252](https://dvsa.atlassian.net/browse/CB2-5252)

## Evidence of Completion
No vehicle booking.
![image](https://user-images.githubusercontent.com/13391709/188656556-95d7e4af-e7ba-486c-8df6-275f10e051f5.png)
Insert a booking.
![image](https://user-images.githubusercontent.com/13391709/188656733-47427a55-9253-44f8-83b6-aad0ded9b397.png)
Booking now present.
![image](https://user-images.githubusercontent.com/13391709/188656825-347ac3a7-c011-4e90-9ebf-bd97346d91bf.png)
Try and insert the same booking.
![image](https://user-images.githubusercontent.com/13391709/188657033-51033f2e-0ac7-4bc0-8a85-a5d861e15867.png)
Still only one booking.
![image](https://user-images.githubusercontent.com/13391709/188657551-f0b0f140-0ab0-4b01-9e57-5d89d9851977.png)
