### PR TITLE
feat(cb2-5834): allow batch item failure retry

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -10,11 +10,13 @@ import { BatchItemFailuresResponse } from './interfaces/BatchItemFailureResponse
  * @param {SQSEvent} event
  * @returns {Promise<BatchItemFailuresResponse>}
  */
-export const handler = async (event: SQSEvent): Promise<BatchItemFailuresResponse> => {
+export const handler = async (
+  event: SQSEvent,
+): Promise<BatchItemFailuresResponse> => {
   const res: BatchItemFailuresResponse = {
     batchItemFailures: [],
   };
-  
+
   if (isEventUndefined(event)) {
     logger.error('ERROR: SQS event is not defined.');
     return Promise.reject('SQS event is empty and cannot be processed');
@@ -36,7 +38,9 @@ export const handler = async (event: SQSEvent): Promise<BatchItemFailuresRespons
 
       await vehicleBooking.insert(vtBooking);
     } catch (error) {
-      logger.error(`Batch item ${id} failed to be processed, putting back on SQS queue for 1 retry`);
+      logger.error(
+        `Batch item ${id} failed to be processed, putting back on SQS queue for 1 retry`,
+      );
       logger.error('Error', error);
       res.batchItemFailures.push({ itemIdentifier: id });
     }

--- a/src/interfaces/BatchItemFailureResponse.ts
+++ b/src/interfaces/BatchItemFailureResponse.ts
@@ -1,7 +1,7 @@
 export interface BatchItemFailuresResponse {
-  batchItemFailures: BatchItemIdentifiers[]
+  batchItemFailures: BatchItemIdentifiers[];
 }
 
 export interface BatchItemIdentifiers {
-  itemIdentifier: string
+  itemIdentifier: string;
 }

--- a/src/interfaces/BatchItemFailureResponse.ts
+++ b/src/interfaces/BatchItemFailureResponse.ts
@@ -1,0 +1,7 @@
+export interface BatchItemFailuresResponse {
+  batchItemFailures: BatchItemIdentifiers[]
+}
+
+export interface BatchItemIdentifiers {
+  itemIdentifier: string
+}

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -1,12 +1,17 @@
 import event from './resources/event.json';
+import doubleEvent from './resources/doubleEvent.json';
 import { handler } from '../src/handler';
 import { SQSEvent } from 'aws-lambda';
 import { VtBooking } from '../src/interfaces/VtBooking';
 import logger from '../src/util/logger';
 import { vehicleBooking } from '../src/vehicleBooking/vehicleBooking';
-import { BatchItemFailuresResponse, BatchItemIdentifiers } from '../src/interfaces/BatchItemFailureResponse';
+import {
+  BatchItemFailuresResponse,
+  BatchItemIdentifiers,
+} from '../src/interfaces/BatchItemFailureResponse';
 
 const bookingEvent = event as unknown as SQSEvent;
+const twoBookingEvent = doubleEvent as unknown as SQSEvent;
 
 jest.mock('../src/vehicleBooking/vehicleBooking', () => {
   return {
@@ -49,7 +54,27 @@ describe('handler function', () => {
 
     const res = await handler(bookingEvent);
 
-    expect(res).toEqual(<BatchItemFailuresResponse>{ batchItemFailures: [{ itemIdentifier: 'string' }] });
+    expect(res).toEqual(<BatchItemFailuresResponse>{
+      batchItemFailures: [{ itemIdentifier: 'string' }],
+    });
+
+    expect(vehicleBooking.insert).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith('Error', new Error('Oh no!'));
+  });
+
+  it('GIVEN an event WHEN an error is thrown on one record THEN the error is returned by the handler but the other event is processed', async () => {
+    process.env.INSERT_BOOKINGS = 'true';
+
+    twoBookingEvent.Records[0].body =
+      '{"name":"Failure","bookingDate": "2022-08-10 10:00:00","vrm":"AB12CDE","testCode":"AAV","testDate":"2022-08-15 10:00:00","pNumber":"P12345"}';
+    twoBookingEvent.Records[1].body =
+      '{"name":"Success","bookingDate": "2022-08-10 10:00:00","vrm":"AB12CDEF","testCode":"AAV","testDate":"2022-08-15 10:00:01","pNumber":"P123456"}';
+
+    const res = await handler(twoBookingEvent);
+
+    expect(res).toEqual(<BatchItemFailuresResponse>{
+      batchItemFailures: [{ itemIdentifier: 'string' }],
+    });
 
     expect(vehicleBooking.insert).toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledWith('Error', new Error('Oh no!'));

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -35,8 +35,6 @@ describe('handler function', () => {
   it('GIVEN an event WHEN the handler is invoked THEN the event is processed.', async () => {
     process.env.INSERT_BOOKINGS = 'true';
 
-    bookingEvent.Records[0].body =
-      '{"name":"Success","bookingDate": "2022-08-10 10:00:00","vrm":"AB12CDE","testCode":"AAV","testDate":"2022-08-15 10:00:00","pNumber":"P12345"}';
     const res: BatchItemFailuresResponse = await handler(bookingEvent);
 
     expect(vehicleBooking.insert).toHaveBeenCalled();
@@ -62,11 +60,6 @@ describe('handler function', () => {
   it('GIVEN an event WHEN an error is thrown on one record THEN the error is returned by the handler but the other event is processed', async () => {
     process.env.INSERT_BOOKINGS = 'true';
 
-    twoBookingEvent.Records[0].body =
-      '{"name":"Failure","bookingDate": "2022-08-10 10:00:00","vrm":"AB12CDE","testCode":"AAV","testDate":"2022-08-15 10:00:00","pNumber":"P12345"}';
-    twoBookingEvent.Records[1].body =
-      '{"name":"Success","bookingDate": "2022-08-10 10:00:00","vrm":"AB12CDEF","testCode":"AAV","testDate":"2022-08-15 10:00:01","pNumber":"P123456"}';
-
     const res = await handler(twoBookingEvent);
 
     expect(res).toEqual(<BatchItemFailuresResponse>{
@@ -79,8 +72,6 @@ describe('handler function', () => {
 
   it('GIVEN an event WHEN the handler is invoked but processing is set to off THEN the event is not processed', async () => {
     process.env.INSERT_BOOKINGS = 'false';
-    bookingEvent.Records[0].body =
-      '{"name":"Success","bookingDate": "2022-08-10 10:00:00","vrm":"AB12CDE","testCode":"AAV","testDate":"2022-08-15 10:00:00","pNumber":"P12345"}';
 
     const res: BatchItemFailuresResponse = await handler(bookingEvent);
 

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -5,10 +5,7 @@ import { SQSEvent } from 'aws-lambda';
 import { VtBooking } from '../src/interfaces/VtBooking';
 import logger from '../src/util/logger';
 import { vehicleBooking } from '../src/vehicleBooking/vehicleBooking';
-import {
-  BatchItemFailuresResponse,
-  BatchItemIdentifiers,
-} from '../src/interfaces/BatchItemFailureResponse';
+import { BatchItemFailuresResponse } from '../src/interfaces/BatchItemFailureResponse';
 
 const bookingEvent = event as unknown as SQSEvent;
 const twoBookingEvent = doubleEvent as unknown as SQSEvent;

--- a/tests/resources/doubleEvent.json
+++ b/tests/resources/doubleEvent.json
@@ -1,0 +1,26 @@
+{
+  "Records": [
+    {
+      "body": "{\"name\":\"Bob's ATF\",\"bookingDate\": \"2022-08-10 10:00:00\",\"vrm\":\"AB12CDE\",\"testCode\":\"AAV\",\"testDate\":\"2022-08-15 00:00:00\",\"pNumber\":\"P12345\"}",
+      "messageId": "string",
+      "receiptHandle": "string",
+      "attributes": "SQSRecordAttributes",
+      "messageAttributes": "SQSMessageAttributes",
+      "md5OfBody": "string",
+      "eventSource": "string",
+      "eventSourceARN": "string",
+      "awsRegion": "string"
+    },
+    {
+      "body": "{\"name\":\"Jim's ATF\",\"bookingDate\": \"2022-08-10 10:00:01\",\"vrm\":\"AB12CDEF\",\"testCode\":\"AAV\",\"testDate\":\"2022-08-15 00:00:01\",\"pNumber\":\"P123456\"}",
+      "messageId": "string",
+      "receiptHandle": "string",
+      "attributes": "SQSRecordAttributes",
+      "messageAttributes": "SQSMessageAttributes",
+      "md5OfBody": "string",
+      "eventSource": "string",
+      "eventSourceARN": "string",
+      "awsRegion": "string"
+    }
+  ]
+}

--- a/tests/resources/doubleEvent.json
+++ b/tests/resources/doubleEvent.json
@@ -1,7 +1,7 @@
 {
   "Records": [
     {
-      "body": "{\"name\":\"Bob's ATF\",\"bookingDate\": \"2022-08-10 10:00:00\",\"vrm\":\"AB12CDE\",\"testCode\":\"AAV\",\"testDate\":\"2022-08-15 00:00:00\",\"pNumber\":\"P12345\"}",
+      "body": "{\"name\":\"Failure\",\"bookingDate\": \"2022-08-10 10:00:00\",\"vrm\":\"AB12CDE\",\"testCode\":\"AAV\",\"testDate\":\"2022-08-15 00:00:00\",\"pNumber\":\"P12345\"}",
       "messageId": "string",
       "receiptHandle": "string",
       "attributes": "SQSRecordAttributes",
@@ -12,7 +12,7 @@
       "awsRegion": "string"
     },
     {
-      "body": "{\"name\":\"Jim's ATF\",\"bookingDate\": \"2022-08-10 10:00:01\",\"vrm\":\"AB12CDEF\",\"testCode\":\"AAV\",\"testDate\":\"2022-08-15 00:00:01\",\"pNumber\":\"P123456\"}",
+      "body": "{\"name\":\"Success\",\"bookingDate\": \"2022-08-10 10:00:01\",\"vrm\":\"AB12CDEF\",\"testCode\":\"AAV\",\"testDate\":\"2022-08-15 00:00:01\",\"pNumber\":\"P123456\"}",
       "messageId": "string",
       "receiptHandle": "string",
       "attributes": "SQSRecordAttributes",

--- a/tests/resources/event.json
+++ b/tests/resources/event.json
@@ -1,7 +1,7 @@
 {
   "Records": [
     {
-      "body": "{\"name\":\"Bob's ATF\",\"bookingDate\": \"2022-08-10 10:00:00\",\"vrm\":\"AB12CDE\",\"testCode\":\"AAV\",\"testDate\":\"2022-08-15 00:00:00\",\"pNumber\":\"P12345\"}",
+      "body": "{\"name\":\"Success\",\"bookingDate\": \"2022-08-10 10:00:00\",\"vrm\":\"AB12CDE\",\"testCode\":\"AAV\",\"testDate\":\"2022-08-15 00:00:00\",\"pNumber\":\"P12345\"}",
       "messageId": "string",
       "receiptHandle": "string",
       "attributes": "SQSRecordAttributes",


### PR DESCRIPTION
## Description

The vt-booking lambda receives SQS events in batches of 10, however it's possible for one of those events to fail. The code in this PR allows for those select events that fail to be retried, instead of the entire batch.

Related issue: [CB2-5834](https://dvsa.atlassian.net/browse/CB2-5834)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works
