### PR TITLE
feat(cb2-6025): insert into booking_header table

### DIFF
--- a/src/database/bookingHeaderDb.ts
+++ b/src/database/bookingHeaderDb.ts
@@ -1,0 +1,22 @@
+import { dbConnection } from './dbConnection';
+import { BookingHeader } from '../interfaces/BookingHeader';
+
+export const bookingHeaderDb = {
+  async insert(bookingHeader: BookingHeader): Promise<number> {
+    const connection = await dbConnection();
+
+    bookingHeader.BOOKING_HEADER_NO = connection.raw(
+      'CvsBookingHeader.nextVal',
+    );
+
+    const results: BookingHeader[] = await connection
+      .insert([bookingHeader], ['BOOKING_HEADER_NO'])
+      .into('BOOKING_HEADER');
+
+    if (results.length === 0) {
+      throw new Error('Insert booking header failed. No data returned.');
+    }
+
+    return results[0].BOOKING_HEADER_NO;
+  },
+};

--- a/src/database/vehicleBookingDb.ts
+++ b/src/database/vehicleBookingDb.ts
@@ -6,29 +6,23 @@ export const vehicleBookingDb = {
   async insert(vehicleBooking: VehicleBooking): Promise<void> {
     const connection = await dbConnection();
 
-    vehicleBooking.FK_BKGHDR_NO = connection.raw(
-      "COALESCE((SELECT MAX(FK_BKGHDR_NO) + 1 from VEHICLE_BOOKING where FK_BKGHDR_USER_NO = 'XR'), 1)",
-    );
-
-    const results: string[] = await connection
+    const results: VehicleBooking[] = await connection
       .insert([vehicleBooking], ['FK_BKGHDR_NO'])
       .into('VEHICLE_BOOKING');
 
     if (results.length === 0) {
-      throw new Error('Insert failed. No data returned.');
+      throw new Error('Insert vehicle booking failed. No data inserted.');
     }
   },
 
   async get(vtBooking: VtBooking): Promise<VehicleBooking[]> {
     const connection = await dbConnection();
 
-    const results: VehicleBooking[] = await connection
+    return connection
       .select()
       .from<VehicleBooking>('VEHICLE_BOOKING')
       .where('VRM', vtBooking.vrm)
       .andWhere('FK_LANTBD_DATE', new Date(vtBooking.testDate))
       .andWhere('FK_APPTYP_APPL_TYP', vtBooking.testCode);
-
-    return results;
   },
 };

--- a/src/interfaces/BookingHeader.ts
+++ b/src/interfaces/BookingHeader.ts
@@ -1,0 +1,43 @@
+import { Knex } from 'knex';
+
+export class BookingHeader {
+  USER_LOCATION = 999;
+
+  USER_NO = 'XR';
+
+  BOOKING_HEADER_NO: Knex.Raw<unknown>;
+
+  DATE_MADE = new Date('0001-01-01 00:00:00');
+
+  NAME0: string;
+
+  TIMESTAMP0 = new Date('0001-01-01 00:00:00');
+
+  USER_ID = 'cvsvbin';
+
+  ACCT_NO = null;
+
+  AGENT_ID = null;
+
+  ADDR_1 = null;
+
+  ADDR_2 = null;
+
+  ADDR_3 = null;
+
+  ADDR_4 = null;
+
+  POSTTOWN = null;
+
+  POSTCODE = null;
+
+  TELEPHONE_NO = null;
+
+  AUTO_LETTER_MARKER = null;
+
+  MAN_LETTER_MARKER = null;
+
+  AUTO_LETTER_SENT = null;
+
+  MANUAL_LETTER_SENT = null;
+}

--- a/src/interfaces/VehicleBooking.ts
+++ b/src/interfaces/VehicleBooking.ts
@@ -1,11 +1,9 @@
-import { Knex } from 'knex';
-
 export class VehicleBooking {
   FK_BKGHDR_USER_LOC = 999;
 
   FK_BKGHDR_USER_NO = 'XR';
 
-  FK_BKGHDR_NO: Knex.Raw<unknown>;
+  FK_BKGHDR_NO: number;
 
   VEHICLE_BOOKING_NO = 1;
 

--- a/src/vehicleBooking/vehicleBooking.ts
+++ b/src/vehicleBooking/vehicleBooking.ts
@@ -1,4 +1,6 @@
 import logger from '../util/logger';
+import { BookingHeader } from '../interfaces/BookingHeader';
+import { bookingHeaderDb } from '../database/bookingHeaderDb';
 import { VehicleBooking } from '../interfaces/VehicleBooking';
 import { vehicleBookingDb } from '../database/vehicleBookingDb';
 import { vehicleDb } from '../database/vehicleDb';
@@ -18,11 +20,18 @@ export const vehicleBooking = {
       return;
     }
 
+    const bookingHeader = {
+      ...new BookingHeader(),
+      NAME0: vtBooking.name.substring(0, 50),
+    };
+
+    const bookingHeaderNo = await bookingHeaderDb.insert(bookingHeader);
     const vehicle = await vehicleDb.get(vtBooking.vrm);
 
     const booking = {
       ...new VehicleBooking(),
-      SHORT_NAME: vtBooking.name,
+      FK_BKGHDR_NO: bookingHeaderNo,
+      SHORT_NAME: vtBooking.name.substring(0, 10),
       VEHICLE_CLASS: vehicle.VEHICLE_CLASS,
       NO_OF_AXLES: vehicle.NO_OF_AXLES,
       TIMESTAMP0: new Date(vtBooking.bookingDate),

--- a/tests/database/bookingHeaderDb.test.ts
+++ b/tests/database/bookingHeaderDb.test.ts
@@ -1,0 +1,50 @@
+import { knex, Knex } from 'knex';
+import { mocked } from 'ts-jest/utils';
+import { BookingHeader } from '../../src/interfaces/BookingHeader';
+import { bookingHeaderDb } from '../../src/database/bookingHeaderDb';
+import { VtBooking } from '../../src/interfaces/VtBooking';
+
+jest.mock('knex');
+const mknex = mocked(knex, true);
+const mKnex = {
+  insert: jest.fn().mockReturnThis(),
+  into: jest
+    .fn()
+    .mockImplementationOnce(() => [{ BOOKING_HEADER_NO: 54321 }])
+    .mockImplementationOnce(() => []),
+  raw: jest.fn(() => null),
+} as unknown as Knex;
+
+mknex.mockImplementationOnce(
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  () => mKnex,
+);
+
+const vtBooking: VtBooking = {
+  name: 'Bobs ATF',
+  bookingDate: '2022-08-10 10:00:00',
+  vrm: 'AB12CDE',
+  testCode: 'AAV',
+  testDate: '2022-08-15 00:00:00',
+  pNumber: 'P12345',
+};
+
+const bookingHeader = {
+  ...new BookingHeader(),
+  NAME0: vtBooking.name.substring(0, 50),
+};
+
+describe('bookingHeaderDb functions', () => {
+  it('GIVEN everything is okay WHEN the data is inserted THEN the objects are mapped correctly and BOOKING_HEADER_NO is returned.', async () => {
+    await bookingHeaderDb.insert(bookingHeader);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mKnex.insert).toBeCalledWith([bookingHeader], ['BOOKING_HEADER_NO']);
+  });
+
+  it('GIVEN an issue with the insert WHEN no results are returned THEN an error is thrown.', async () => {
+    await expect(bookingHeaderDb.insert(bookingHeader)).rejects.toThrow(
+      'Insert booking header failed. No data returned.',
+    );
+  });
+});

--- a/tests/database/vehicleBookingDb.test.ts
+++ b/tests/database/vehicleBookingDb.test.ts
@@ -94,7 +94,7 @@ describe('vehicleBookingDb functions', () => {
 
   it('GIVEN an issue with the insert WHEN no results are returned THEN an error is thrown.', async () => {
     await expect(vehicleBookingDb.insert(vehicleBooking)).rejects.toThrow(
-      'Insert failed. No data returned.',
+      'Insert vehicle booking failed. No data inserted.',
     );
   });
 

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -32,6 +32,19 @@ describe('handler function', () => {
     jest.clearAllMocks();
   });
 
+  it('GIVEN INSERT_BOOKINGS is not set WHEN the handler is invoked THEN the function returns an error.', async () => {
+    const res: BatchItemFailuresResponse = await handler(bookingEvent);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error',
+      new Error('INSERT_BOOKINGS environment variable must be true or false'),
+    );
+    expect(vehicleBooking.insert).not.toHaveBeenCalled();
+    expect(res).toEqual(<BatchItemFailuresResponse>{
+      batchItemFailures: [{ itemIdentifier: 'string' }],
+    });
+  });
+
   it('GIVEN an event WHEN the handler is invoked THEN the event is processed.', async () => {
     process.env.INSERT_BOOKINGS = 'true';
 


### PR DESCRIPTION
## Description
Amend VT Booking function to insert into booking_header table. A requirement to insert into the booking_header table was found during the first round of testing. This is to satisfy the requirements of a trigger on the vehicle_test table.

Related issue: [CB2-6025](https://dvsa.atlassian.net/browse/CB2-6025)
## Evidence of Completion
No booking in the database.
![image](https://user-images.githubusercontent.com/13391709/192469521-cbe1a3d6-23c9-41cc-b1ba-151403def1fc.png)

Lambda invoked manually with a dynamodb stream event.
![image](https://user-images.githubusercontent.com/13391709/192469563-9c7b5422-dc9c-4979-b88b-0dcfc4459209.png)
![image](https://user-images.githubusercontent.com/13391709/192469586-94191f44-96c0-4d69-bb62-09246fde8ebd.png)

Data inserted into the booking_header table and the vehicle_booking table.
![image](https://user-images.githubusercontent.com/13391709/192469649-1abb2ccb-0a6f-45eb-ac58-79d8515d0a1a.png)
Notice the STATUS0 and LAST_PRES_NAME are 40 and TIP TRAILERS respectively.

Manually result the test via a direct insertion into the database.
![image](https://user-images.githubusercontent.com/13391709/192470128-2897cde0-3e3c-428a-8567-9f388932fb67.png)

Data inserted into the vehicle_test table.
![image](https://user-images.githubusercontent.com/13391709/192470163-53cc42db-7388-4210-8449-a1909fa90523.png)
The trigger on the vehicle_test table has updated STATUS0 to 219. It has also updated the vehicle table with the NAME0 from the booking_header table.