### PR TITLE
Filter out inactive sites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ Database_Host=localhost
 Database_User=user
 Database_Password=password
 Database_Database=db1
+ACTIVE_SITES_SECRET_NAME=env/activesites

--- a/src/util/getActiveSites.ts
+++ b/src/util/getActiveSites.ts
@@ -1,0 +1,35 @@
+import { SecretsManager } from 'aws-sdk';
+import logger from './logger';
+
+export const getActiveSites = async (): Promise<string[]> => {
+  if (!process.env.ACTIVE_SITES_SECRET_NAME) {
+    throw new Error(
+      'Environment variable ACTIVE_SITES_SECRET_NAME is not set.',
+    );
+  }
+
+  const activeSites = process.env.ACTIVE_SITES;
+
+  if (activeSites) {
+    logger.debug('Retrieved active sites from cache.');
+
+    return activeSites.split(',');
+  }
+
+  logger.debug('Retrieving active sites from SecretsManager.');
+  const secretsManager = new SecretsManager();
+  const secretValue = await secretsManager
+    .getSecretValue({ SecretId: process.env.ACTIVE_SITES_SECRET_NAME })
+    .promise();
+
+  if (secretValue?.SecretString !== undefined) {
+    logger.debug('Retrieved active sites from SecretsManager.');
+    process.env.ACTIVE_SITES = secretValue.SecretString;
+
+    return secretValue.SecretString.split(',');
+  }
+
+  throw new Error(
+    'Unable to retrieve active sites, SecretString was undefined.',
+  );
+};

--- a/tests/resources/notMigratedEvent.json
+++ b/tests/resources/notMigratedEvent.json
@@ -1,0 +1,15 @@
+{
+  "Records": [
+    {
+      "body": "{\"name\":\"Success\",\"bookingDate\": \"2022-08-10 10:00:00\",\"vrm\":\"AB12CDE\",\"testCode\":\"AAV\",\"testDate\":\"2022-08-15 00:00:00\",\"pNumber\":\"P54321\"}",
+      "messageId": "string",
+      "receiptHandle": "string",
+      "attributes": "SQSRecordAttributes",
+      "messageAttributes": "SQSMessageAttributes",
+      "md5OfBody": "string",
+      "eventSource": "string",
+      "eventSourceARN": "string",
+      "awsRegion": "string"
+    }
+  ]
+}

--- a/tests/util/getActiveSites.test.ts
+++ b/tests/util/getActiveSites.test.ts
@@ -1,0 +1,98 @@
+import { getActiveSites } from '../../src/util/getActiveSites';
+import logger from '../../src/util/logger';
+
+const responses = jest.fn((SecretId) => {
+  switch (SecretId) {
+    case 'Success':
+      return {
+        SecretString: "'P12345','P123456'",
+      };
+    case 'NoSecret':
+      return undefined;
+    default:
+      throw Error('Failed to get secret');
+  }
+});
+
+jest.mock('aws-sdk', () => {
+  return {
+    config: {
+      update() {
+        return {};
+      },
+    },
+    SecretsManager: jest.fn(() => {
+      return {
+        getSecretValue: jest.fn(({ SecretId }) => {
+          return {
+            promise: () => responses(SecretId),
+          };
+        }),
+      };
+    }),
+  };
+});
+
+jest.mock('../../src/util/logger');
+
+describe('getActiveSites', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GIVEN an invocation WHEN getting secret THEN return array6 of active sites', async () => {
+    process.env.ACTIVE_SITES_SECRET_NAME = 'Success';
+    delete process.env.ACTIVE_SITES;
+    const result = await getActiveSites();
+
+    expect(responses).toHaveBeenCalledTimes(1);
+    expect(responses).toHaveBeenCalledWith('Success');
+    expect(Object.keys(result).length).toBe(2);
+    expect.assertions(3);
+  });
+
+  it('GIVEN no secret returned WHEN getting secret THEN return nothing', async () => {
+    process.env.ACTIVE_SITES_SECRET_NAME = 'NoSecret';
+    delete process.env.ACTIVE_SITES;
+
+    await expect(getActiveSites()).rejects.toThrow(
+      'Unable to retrieve active sites, SecretString was undefined.',
+    );
+    expect(responses).toHaveBeenCalledTimes(1);
+    expect(responses).toHaveBeenCalledWith('NoSecret');
+    expect.assertions(3);
+  });
+
+  it('GIVEN no ACTIVE_SITES_SECRET_NAME environmental variable WHEN getting secret THEN throw error', async () => {
+    delete process.env.ACTIVE_SITES_SECRET_NAME;
+    delete process.env.ACTIVE_SITES;
+
+    await expect(getActiveSites()).rejects.toThrow(
+      'Environment variable ACTIVE_SITES_SECRET_NAME is not set.',
+    );
+    expect(responses).toHaveBeenCalledTimes(0);
+    expect.assertions(2);
+  });
+
+  it('GIVEN an error occurs WHEN getting secret THEN throw error', async () => {
+    process.env.ACTIVE_SITES_SECRET_NAME = 'Failure';
+    delete process.env.ACTIVE_SITES;
+
+    await expect(getActiveSites()).rejects.toThrow('Failed to get secret');
+    expect(responses).toHaveBeenCalledTimes(1);
+    expect(responses).toHaveBeenCalledWith('Failure');
+    expect.assertions(3);
+  });
+
+  it('GIVEN getActiveSites uses a cache WHEN multiple calls are made THEN all but the first will use the cache', async () => {
+    process.env.ACTIVE_SITES_SECRET_NAME = 'Success';
+    await getActiveSites();
+    await getActiveSites();
+
+    expect(responses).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Retrieved active sites from cache.',
+    );
+    expect.assertions(2);
+  });
+});


### PR DESCRIPTION
## Description

It has been identified that only test results from migrated ATFs should create entries in the VT vehicle_booking table. To enable this logic the vt-booking function requires access to the active_sites secret so it knows what sites have been migrated. It then needs to filter out the results from non-migrated sites.

Related issue: [CB2-6211](https://dvsa.atlassian.net/browse/CB2-6211)

## Evidence of Completion
No bookings for user XR.
![image](https://user-images.githubusercontent.com/13391709/194040599-2ac5e4c3-7921-4b45-bf3f-784d8459512e.png)

Lambda called with station not in the active_sites secret.
![image](https://user-images.githubusercontent.com/13391709/194040849-b94da486-8082-4d63-8f0e-6d105df1a720.png)

No bookings for user XR still.
![image](https://user-images.githubusercontent.com/13391709/194040975-9d1f3387-64d7-4694-8887-30e52e27ead3.png)

Lambda called with station in the active_sites secret.
![image](https://user-images.githubusercontent.com/13391709/194042052-773ebce6-4afc-4faa-ad1c-f5eb85951e92.png)

Booking inserted for user XR.
![image](https://user-images.githubusercontent.com/13391709/194041385-57107453-b10b-4285-8106-d52c128503d0.png)
